### PR TITLE
Print warnings about unknown/unloaded instructions to stderr instead of stdout

### DIFF
--- a/src/com/company/Fingerprint.java
+++ b/src/com/company/Fingerprint.java
@@ -1,7 +1,5 @@
 package com.company;
 
-import javafx.util.Pair;
-
 import java.time.LocalDateTime;
 import java.util.Calendar;
 import java.util.HashMap;

--- a/src/com/company/FungeSpace.java
+++ b/src/com/company/FungeSpace.java
@@ -1,7 +1,5 @@
 package com.company;
 
-import com.sun.xml.internal.ws.policy.privateutil.PolicyUtils;
-
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/com/company/FungeSpace.java
+++ b/src/com/company/FungeSpace.java
@@ -560,7 +560,7 @@ public class FungeSpace {
             int num = instr - 'A';
             if (ip.semantics[num].isEmpty()) {
                 ip.reflect();
-                System.out.println("[FungeJ] WARNING: unloaded semantic " + (char)instr + " called at " + ip.pos + ".");
+                System.err.println("[FungeJ] WARNING: unloaded semantic " + (char)instr + " called at " + ip.pos + ".");
             } else {
                 ip.semantics[num].peek().accept(ip);
             }
@@ -596,7 +596,7 @@ public class FungeSpace {
         }
         else {
             ip.reflect();
-            System.out.println("[FungeJ] WARNING: unknown instruction " + instr + " encountered at " + ip.pos +
+            System.err.println("[FungeJ] WARNING: unknown instruction " + instr + " encountered at " + ip.pos +
                     " by IP #" + ip.id + ".");
         }
     }

--- a/src/com/company/Main.java
+++ b/src/com/company/Main.java
@@ -24,7 +24,7 @@ public class Main {
                 str = new String(Files.readAllBytes(Paths.get(filename)), Charset.forName("ISO-8859-1"));
                 str = str.replaceAll("\\r\\n?", "\n");
             } catch (Exception e) {
-                System.out.println("File couldn't be opened for reading.");
+                System.err.println("File couldn't be opened for reading.");
                 return;
             }
             int dim = 2;
@@ -40,9 +40,9 @@ public class Main {
             long now = System.nanoTime();
             FungeSpace space = new FungeSpace(str, 2);
             space.runProgram();
-            System.out.println("\nProgram took " + (System.nanoTime() - now)/1000000 + "ms to construct and run.");
+            System.err.println("\nProgram took " + (System.nanoTime() - now)/1000000 + "ms to construct and run.");
         } else {
-            System.out.println("You must specify a file to run.");
+            System.err.println("You must specify a file to run.");
         }
     }
 }


### PR DESCRIPTION
This way the warnings can be easily suppressed by redirecting stderr to /dev/null,
which is more in line with the spec and the behavior of other Befunge-98 interpreters.

I also changed `System.out` to `System.err` in a couple of other places.

Also, shouldn't this repo be called FungeJ? Just Funge seems too generic.